### PR TITLE
Fix typo in application key

### DIFF
--- a/lib/tidy_ex.ex
+++ b/lib/tidy_ex.ex
@@ -38,7 +38,7 @@ defmodule TidyEx do
   Internal use
   """
   def options() do
-    Application.get_env(:tidyt_ex, :options, [{"TidyShowWarnings", "no"}, {"TidyBodyOnly", "yes"}, {"TidyQuiet", "yes"}, {"TidyVertSpace", "auto"}, {"TidyIndentSpaces", "0"}])
+    Application.get_env(:tidy_ex, :options, [{"TidyShowWarnings", "no"}, {"TidyBodyOnly", "yes"}, {"TidyQuiet", "yes"}, {"TidyVertSpace", "auto"}, {"TidyIndentSpaces", "0"}])
   end
 
   @doc """


### PR DESCRIPTION
This makes the application key used to query `Application.get_env/3` consistent with the application key defined in the MixProject module (https://github.com/f34nk/tidy_ex/blob/master/mix.exs#L6) 

Related to: https://github.com/f34nk/tidy_ex/issues/5